### PR TITLE
Fix `react-router-dom` dependencies and bump `react-scripts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "mdbreact": "^4.9.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
-    "react-router-dom": "^4.3.1",
-    "react-scripts": "2.1.3"
+    "react-scripts": "^3.4.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
`react-router-dom` dependency was quite old, this pgk was
already part of mdbreact dependencies. This mismatch caused
the following error [[0]]. This change also bumps the version
of `react-scripts`.

[0]: https://mdbootstrap.com/support/react/mdbnavlink-causes-you-should-not-use-navlink-outside-a-router/