### PR TITLE
Fix: update react-router-dom to 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "mdbreact": "^4.9.0",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
-    "react-router-dom": "^4.3.1",
+    "react-router-dom": "^5.2.0",
     "react-scripts": "2.1.3"
   },
   "scripts": {


### PR DESCRIPTION
Fixing #2.

Quoted from #4 : `react-router-dom` dependency was quite old.

I've tried solution posted at #4 but removing react-router-dom from dependencies would make this app failed to run. Therefore, only updating react-router-dom should be suffice to fix this problem.